### PR TITLE
fix: set output token ids with async scheduling according to sampling params

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -564,6 +564,13 @@ class SamplingParams(
         # For internal use only. Backward compatibility not guaranteed
         return self._bad_words_token_ids
 
+    @property
+    def requires_token_ids(self) -> bool:
+        """Whether this sampling params requires output_token_ids for logits processing."""
+        return (
+            self.thinking_token_budget is not None
+        )
+
     def clone(self) -> "SamplingParams":
         """Deep copy, but maybe not the LogitsProcessor objects.
 

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -416,6 +416,10 @@ class InputBatch:
                 self.bad_words_token_ids[req_index] = (
                     sampling_params.bad_words_token_ids
                 )
+
+            self.logits_processing_needs_token_ids[req_index] = (
+                sampling_params.requires_token_ids
+            )
         elif pooling_params := request.pooling_params:
             pooling_states = request.pooling_states
             assert pooling_states is not None
@@ -825,6 +829,7 @@ class InputBatch:
             not self.no_penalties
             or bool(self.bad_words_token_ids)
             or self.logitsprocs_need_output_token_ids
+            or self.logits_processing_needs_token_ids[:num_reqs].any()
         )
         output_token_ids = (
             cast(list[list[int]], self.req_output_token_ids)


### PR DESCRIPTION
- some sampling params need output token ids even under async scheduling